### PR TITLE
Draft: To bring the stepzen cli npm package github workflow cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,28 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - id: install-stepzen-cli
+    - name: Get version
+      id: get-version
+      shell: bash
+      run: |
+        if [[ "${VERSION}" == "latest" ]]; then
+          echo "cli_version=$(npm view stepzen version)" >> $GITHUB_OUTPUT
+        else
+          echo "cli_version=${VERSION}" >> $GITHUB_OUTPUT
+        fi
+      env:
+        VERSION: ${{ inputs.version }}
+        
+    - name: Cache stepzen cli
+      id: cache-stepzen-cli
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/stepzen-install
+        key: stepzen-cli-${{ steps.get-version.outputs.cli_version }}
+    
+    - name: create npm package for cache
+      if: steps.cache-stepzen-cli.outputs.cache-hit != 'true'
       # retry due to occasional npm failure
       uses: nick-fields/retry@v3
       with:
@@ -23,6 +44,14 @@ runs:
         max_attempts: 3
         retry_wait_seconds: 2
         shell: bash
-        command: npm install --location=global stepzen@${{ inputs.version }}  --verbose
+        command: |
+          mkdir -p ~/stepzen-install  
+          npm pack stepzen@${{ steps.get-version.outputs.cli_version }} --pack-destination ~/stepzen-install            
+    
+    - name: Install stepzen cli from cache
+      shell: bash
+      run: |
+        npm install --location=global ~/stepzen-install/stepzen-${{ steps.get-version.outputs.cli_version }}.tgz      
+
     - run: stepzen version
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -19,13 +19,11 @@ runs:
       id: get-version
       shell: bash
       run: |
-        if [[ "${VERSION}" == "latest" ]]; then
+        if [[ "${{ inputs.version }}" == "latest" ]]; then
           echo "cli_version=$(npm view stepzen version)" >> $GITHUB_OUTPUT
         else
           echo "cli_version=${VERSION}" >> $GITHUB_OUTPUT
-        fi
-      env:
-        VERSION: ${{ inputs.version }}
+        fi      
         
     - name: Cache stepzen cli
       id: cache-stepzen-cli


### PR DESCRIPTION
This code change introduces a version check and implements caching for the StepZen CLI NPM package within the GitHub workflow. If the required version is already available in the cache, it will be used directly; otherwise, the package will be downloaded from the NPM registry only when necessary, optimizing redundant downloads.